### PR TITLE
Add CUIBitmapEncoding and UTI to CUIThemeRendition

### DIFF
--- a/Sources/AssetCatalogWrapper/AssetCatalogWrapper.swift
+++ b/Sources/AssetCatalogWrapper/AssetCatalogWrapper.swift
@@ -635,3 +635,46 @@ fileprivate extension Optional {
     }
     
 }
+
+extension CUIBitmapEncoding : CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .none:
+            return "uncompressed"
+        case .RLE:
+            return "rle"
+        case .ZIP:
+            return "zip"
+        case .LZVN:
+            return "lzvn"
+        case .LZFSE:
+            return "lzfse"
+        case .JPEG_LZFSE:
+            return "jpeg-lzfse"
+        case .blurred:
+            return "blurred"
+        case .ASTC:
+            return "astc"
+        case .DXTC:
+            return "dxtc"
+        case .paletteImg:
+            return "palette-img"
+        case .HEVC:
+            return "hevc"
+        case .deepmapLZFSE:
+            return "deepmap-lzfse"
+        case .deepmap2:
+            return "deepmap2"
+        case .ARGB:
+            return "ARGB"
+        case .JPEG:
+            return "JPEG"
+        case .HEIF:
+            return "HEIF"
+        case .unknown:
+            return "(Unknown)"
+        default:
+            return "(Unknown)"
+        }
+    }
+}

--- a/Sources/CFrameworks/CoreUI/CUIThemeRendition.h
+++ b/Sources/CFrameworks/CoreUI/CUIThemeRendition.h
@@ -23,6 +23,27 @@
 #pragma clang diagnostic push
 // for the `Pointer is missing a nullability type specifier` warnings:
 #pragma clang diagnostic ignored "-Wnullability-completeness"
+
+typedef NS_ENUM(NSInteger, CUIBitmapEncoding) {
+    CUIBitmapEncodingNone = 0,
+    CUIBitmapEncodingRLE = 1,
+    CUIBitmapEncodingZIP = 2,
+    CUIBitmapEncodingLZVN= 3,
+    CUIBitmapEncodingLZFSE = 4,
+    CUIBitmapEncodingJPEG_LZFSE = 5,
+    CUIBitmapEncodingBlurred = 6,
+    CUIBitmapEncodingASTC = 7,
+    CUIBitmapEncodingDXTC = 8,
+    CUIBitmapEncodingPaletteImg = 9,
+    CUIBitmapEncodingHEVC = 10,
+    CUIBitmapEncodingDeepmapLZFSE = 11,
+    CUIBitmapEncodingDeepmap2 = 12,
+    CUIBitmapEncodingARGB = 13,
+    CUIBitmapEncodingJPEG = 14,
+    CUIBitmapEncodingHEIF = 15,
+    CUIBitmapEncodingUnknown = 16
+};
+
 @interface CUIThemeRendition : NSObject
 @property(nonatomic) long long type;
 @property(nonatomic) unsigned int subtype;
@@ -36,6 +57,7 @@
 - (NSString * _Nonnull)name;
 - (unsigned long long)colorSpaceID;
 - (double)scale;
+- (NSDictionary *)properties;
 - (long long)templateRenderingMode;
 - (NSString * _Nullable)utiType;
 - (bool)isHeaderFlaggedFPO;
@@ -59,6 +81,8 @@
 - (struct CGSize)unslicedSize;
 - (_Nonnull id)initWithCSIData:(NSData *)arg1 forKey:(const struct renditionkeytoken *)arg2;
 - (NSData *)data; // Null if the classForCoder isn't _CUIRawDataRendition
+- (NSString *)utiType;
+- (CUIBitmapEncoding)bitmapEncoding;
 @end
 
 


### PR DESCRIPTION
Adds support for CUIBitmapEncoding (which was determined by examining AssetUtil), and accessing the UTI value. These are to extend `Data` capabilities in Samra in a later change.