### PR TITLE
Fix up nullability of SVG and PDF Types and remove duplicated item.

### DIFF
--- a/Sources/AssetCatalogWrapper/AssetCatalogWrapper.swift
+++ b/Sources/AssetCatalogWrapper/AssetCatalogWrapper.swift
@@ -150,9 +150,13 @@ public class Rendition: Hashable {
         case .pdf:
             return cuiRend.createImageFromPDFRendition(withScale: _getScreenScale())?.takeUnretainedValue()
         case .svg:
-            let document = SVGDocument(doc: cuiRend.svgDocument())
-            document.destroyUponDeinitialization = false
-            return document.cgImage()
+            if let svgDocument = cuiRend.svgDocument() {
+                let document = SVGDocument(doc: svgDocument)
+                document.destroyUponDeinitialization = false
+                return document.cgImage()
+            }
+            return nil
+
         default:
             return nil
         }

--- a/Sources/CFrameworks/CoreUI/CUIThemeRendition.h
+++ b/Sources/CFrameworks/CoreUI/CUIThemeRendition.h
@@ -63,7 +63,7 @@ typedef NS_ENUM(NSInteger, CUIBitmapEncoding) {
 - (bool)isInternalLink;
 - (CUIRenditionKey *)linkingToRendition;
 #if HAS_CORE_SVG
-- (CGSVGDocumentRef)svgDocument;
+- (CGSVGDocumentRef _Nullable)svgDocument;
 #endif
 - (struct CGRect)_destinationFrame;
 - (CGImageRef _Nullable)uncroppedImage;
@@ -72,8 +72,7 @@ typedef NS_ENUM(NSInteger, CUIBitmapEncoding) {
 - (bool)substituteWithSystemColor;
 - (NSString *)systemColorName;
 - (CGImageRef)createImageFromPDFRenditionWithScale:(double)arg1;
-- (CGPDFDocumentRef)pdfDocument;
-- (struct CGRect)_destinationFrame;
+- (CGPDFDocumentRef _Nullable)pdfDocument;
 - (struct CGSize)unslicedSize;
 - (_Nonnull id)initWithCSIData:(NSData *)arg1 forKey:(const struct renditionkeytoken *)arg2;
 - (_Nullable id)initWithCSIData:(NSData *)csidata forKey:(const struct renditionkeytoken *)key version:(unsigned int)version;


### PR DESCRIPTION
Given that the SVG and PDF can be null, we should probably let Swift know.